### PR TITLE
Sanitizing object keys to avoid unpredictable behavior

### DIFF
--- a/src/lib/DataUpdaters/S3BasicNftMetadataDataUpdater.ts
+++ b/src/lib/DataUpdaters/S3BasicNftMetadataDataUpdater.ts
@@ -22,24 +22,29 @@ export default class S3BasicNftMetadataDataUpdater extends S3BasicFileDataUpdate
     }
 
     console.log(`Revealing "${this.resourceName}" for token ${tokenId.toString()}...`);
+    
+    const sourceKey = this.buildSourceObjectKey(tokenId);
+    const destinationKey = this.buildDestinationObjectKey(tokenId);
 
     try {
       const sourceData = await this.s3.getObject({
         Bucket: this.s3Config.bucketName,
-        Key: this.buildSourceObjectKey(tokenId),
+        Key: sourceKey,
       }).promise();
 
-      let sourceContent = this.metadataUpdater(tokenId, JSON.parse(sourceData.Body.toString()));
+      const sourceContent = this.metadataUpdater(tokenId, JSON.parse(sourceData.Body.toString()));
 
       await this.s3.upload({
         Bucket: this.s3Config.bucketName,
-        Key: this.buildDestinationObjectKey(tokenId),
+        Key: destinationKey,
         ContentType: sourceData.ContentType,
         Body: JSON.stringify(sourceContent, null, 2),
         ACL: "public-read",
       }).promise();
     } catch (error) {
       console.error(`Error copying "${this.resourceName}" for token ${tokenId.toString()}.`);
+      console.error(`Source key: ${sourceKey}`);
+      console.error(`Destination key: ${destinationKey}`);
       console.error(error);
     }
   }


### PR DESCRIPTION
While testing with different configurations I discovered that leading `/` in object keys may create issues with Digitalocean's spaces (I'm not sure if the same applies to AWS). This PR introduces a sanitization function that ensures object keys do not have leading or double `/`.

From my understanding of the issue, this may also fix https://github.com/hashlips-lab/safe-nft-metadata-provider/issues/50.