### PR TITLE
[BC] Adding a reaction delay to the UpdateTokenOnMintRuntime

### DIFF
--- a/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
+++ b/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
@@ -6,6 +6,7 @@ import RuntimeInterface from "../RuntimeInterface";
 export default class UpdateTokenOnMintRuntime implements RuntimeInterface {
   public constructor(
     private contract: ERC721Contract,
+    private reactionDelay: number,
     private fromAddress: string = ethers.utils.getAddress("0x0000000000000000000000000000000000000000"),
   ) {
   }
@@ -15,8 +16,11 @@ export default class UpdateTokenOnMintRuntime implements RuntimeInterface {
       this.contract.filters.Transfer(this.fromAddress),
       async (from: string, to: string, tokenId: BigNumber) => {
         console.log(`Token #${tokenId} was minted by ${to}...`);
-    
-        await collectionDataUpdater.updateSingleToken(tokenId);
+
+        // A delay helps avoiding out-of-sync readings during the next steps...
+        setTimeout(async () => {
+          await collectionDataUpdater.updateSingleToken(tokenId);
+        }, this.reactionDelay);
       },
     );
   }


### PR DESCRIPTION
Testing revealed that sometimes the "totalSupply" reading may return an old value if performed too close to a "Transfer" event emitted at mint.

Adding a customizable reaction delay makes it possible to tweak the value depending on the needs.

A suggested value for the **Ethereum mainnet** is between `10000` to `20000` milliseconds.

⚠️ **Warning** ⚠️
I know this is a breaking change but it will be merged with the next minor version for the following reasons:
* the adoption of this library is still pretty low since the main project using it was still in beta version
* this feature is required for the library to work properly