### PR TITLE
Using seconds instead of milliseconds for the reaction delay (UpdateTokenOnMintRuntime)

### DIFF
--- a/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
+++ b/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
@@ -20,7 +20,7 @@ export default class UpdateTokenOnMintRuntime implements RuntimeInterface {
         // A delay helps avoiding out-of-sync readings during the next steps...
         setTimeout(async () => {
           await collectionDataUpdater.updateSingleToken(tokenId);
-        }, this.reactionDelay);
+        }, this.reactionDelay * 1000);
       },
     );
   }

--- a/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
+++ b/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
@@ -15,10 +15,12 @@ export default class UpdateTokenOnMintRuntime implements RuntimeInterface {
     this.contract.on(
       this.contract.filters.Transfer(this.fromAddress),
       async (from: string, to: string, tokenId: BigNumber) => {
-        console.log(`Token #${tokenId} was minted by ${to}...`);
-
+        console.log(`Token #${tokenId} has been minted by ${to}, updating it in ${this.reactionDelay} seconds...`);
+        
         // A delay helps avoiding out-of-sync readings during the next steps...
         setTimeout(async () => {
+          console.log(`Running scheduled update for token #${tokenId} (minted)...`);
+
           await collectionDataUpdater.updateSingleToken(tokenId);
         }, this.reactionDelay * 1000);
       },


### PR DESCRIPTION
This keeps consistency with `UpdateAllTokensEveryNSecondsRuntime`.