### PR TITLE
Adding support for eventData object being passed through steps

### DIFF
--- a/src/lib/CollectionStatusProviderInterface.ts
+++ b/src/lib/CollectionStatusProviderInterface.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers";
+import EventDataInterface from "./EventDataInterface";
 
 export default interface CollectionStatusProviderInterface {
   getTokenIds: () => Promise<BigNumber[]>;
-  isTokenRevealed: (tokenId: BigNumber) => Promise<boolean>;
-  refresh: () => Promise<void>;
+  processEventDataBeforeUpdate: (eventData: EventDataInterface) => Promise<EventDataInterface>;
 }

--- a/src/lib/CollectionStatusProviders/ERC721CollectionStatusProvider.ts
+++ b/src/lib/CollectionStatusProviders/ERC721CollectionStatusProvider.ts
@@ -1,5 +1,20 @@
 import { BigNumber, Contract } from "ethers";
 import CollectionStatusProviderInterface from "../CollectionStatusProviderInterface";
+import EventDataInterface from "../EventDataInterface";
+import { isFullUpdate } from "../../CollectionDataUpdater";
+import { isNewMint } from "../Runtimes/UpdateTokenOnMintRuntime";
+
+export const EVENT_DATA_IS_REVEALED = "__isRevealed";
+
+export const isRevealed = (eventData: EventDataInterface): boolean|undefined => {
+  return eventData[EVENT_DATA_IS_REVEALED];
+};
+
+export const EVENT_DATA_FORCED_COLLECTION_STATUS_REFRESH = "__forcedCollectionStatusRefresh";
+
+export const forcedCollectionStatusRefresh = (eventData: EventDataInterface): boolean|undefined => {
+  return eventData[EVENT_DATA_FORCED_COLLECTION_STATUS_REFRESH];
+};
 
 export default class ERC721CollectionStatusProvider implements CollectionStatusProviderInterface {
   private totalSupply: BigNumber = BigNumber.from(0);
@@ -25,11 +40,19 @@ export default class ERC721CollectionStatusProvider implements CollectionStatusP
     return this.tokenIds;
   }
 
-  public async isTokenRevealed(tokenId: BigNumber): Promise<boolean> {
-    return tokenId.lte(this.totalSupply);
-  }
+  public async processEventDataBeforeUpdate(eventData: EventDataInterface): Promise<EventDataInterface> {
+    if (isNewMint(eventData) === true) {
+      if (eventData.tokenId.gt(this.totalSupply)) {
+        this.totalSupply = eventData.tokenId;
+      }
 
-  public async refresh(): Promise<void> {
-    this.totalSupply = await this.contract.totalSupply();
+      return { [EVENT_DATA_IS_REVEALED]: true, ...eventData }
+    }
+
+    if (forcedCollectionStatusRefresh(eventData) === true || (isFullUpdate(eventData) === true && eventData.tokenId.eq(this.startTokenId))) {
+      this.totalSupply = await this.contract.totalSupply();
+    }
+
+    return { [EVENT_DATA_IS_REVEALED]: eventData.tokenId.lte(this.totalSupply), ...eventData }
   }
 }

--- a/src/lib/CollectionStatusProviders/TestingCollectionStatusProvider.ts
+++ b/src/lib/CollectionStatusProviders/TestingCollectionStatusProvider.ts
@@ -1,5 +1,7 @@
 import { BigNumber } from "ethers";
 import CollectionStatusProviderInterface from "../CollectionStatusProviderInterface";
+import EventDataInterface from "../EventDataInterface";
+import { EVENT_DATA_IS_REVEALED } from "./ERC721CollectionStatusProvider";
 
 export default class TestingCollectionStatusProvider implements CollectionStatusProviderInterface {
   private totalSupply: BigNumber;
@@ -24,7 +26,7 @@ export default class TestingCollectionStatusProvider implements CollectionStatus
     return tokenId.lte(this.totalSupply);
   }
 
-  public async refresh(): Promise<void> {
-    // Nothing to do here...
+  public async processEventDataBeforeUpdate(eventData: EventDataInterface): Promise<EventDataInterface> {
+    return { [EVENT_DATA_IS_REVEALED]: eventData.tokenId.lte(this.totalSupply), ...eventData }
   }
 }

--- a/src/lib/DataUpdaterInterface.ts
+++ b/src/lib/DataUpdaterInterface.ts
@@ -1,5 +1,5 @@
-import { BigNumber } from "ethers";
+import EventDataInterface from "./EventDataInterface";
 
 export default interface DataUpdaterInterface {
-  updateToken: (tokenId: BigNumber, isRevealed: boolean) => Promise<void>;
+  updateToken: (eventData: EventDataInterface) => Promise<EventDataInterface>;
 }

--- a/src/lib/DataUpdaters/S3BasicNftMetadataDataUpdater.ts
+++ b/src/lib/DataUpdaters/S3BasicNftMetadataDataUpdater.ts
@@ -32,6 +32,10 @@ export default class S3BasicNftMetadataDataUpdater extends S3BasicFileDataUpdate
         Key: sourceKey,
       }).promise();
 
+      if (sourceData.Body === undefined) {
+        throw "Object body was undefined.";
+      }
+
       const sourceContent = this.metadataUpdater(tokenId, JSON.parse(sourceData.Body.toString()));
 
       await this.s3.upload({

--- a/src/lib/EventDataInterface.ts
+++ b/src/lib/EventDataInterface.ts
@@ -1,0 +1,6 @@
+import { BigNumber } from "ethers";
+
+export default interface EventDataInterface {
+  tokenId: BigNumber;
+  [key: string]: any;
+}

--- a/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
+++ b/src/lib/Runtimes/UpdateTokenOnMintRuntime.ts
@@ -2,11 +2,17 @@ import { BigNumber, ethers } from "ethers";
 import CollectionDataUpdater from "../../CollectionDataUpdater";
 import ERC721Contract from "../Util/Contracts/ERC721Contract";
 import RuntimeInterface from "../RuntimeInterface";
+import EventDataInterface from "../EventDataInterface";
+
+export const EVENT_DATA_IS_NEW_MINT = "__isNewMint";
+
+export const isNewMint = (eventData: EventDataInterface): boolean|undefined => {
+  return eventData[EVENT_DATA_IS_NEW_MINT];
+};
 
 export default class UpdateTokenOnMintRuntime implements RuntimeInterface {
   public constructor(
     private contract: ERC721Contract,
-    private reactionDelay: number,
     private fromAddress: string = ethers.utils.getAddress("0x0000000000000000000000000000000000000000"),
   ) {
   }
@@ -15,14 +21,9 @@ export default class UpdateTokenOnMintRuntime implements RuntimeInterface {
     this.contract.on(
       this.contract.filters.Transfer(this.fromAddress),
       async (from: string, to: string, tokenId: BigNumber) => {
-        console.log(`Token #${tokenId} has been minted by ${to}, updating it in ${this.reactionDelay} seconds...`);
-        
-        // A delay helps avoiding out-of-sync readings during the next steps...
-        setTimeout(async () => {
-          console.log(`Running scheduled update for token #${tokenId} (minted)...`);
+        console.log(`Token #${tokenId} has been minted by ${to}, updating it...`);
 
-          await collectionDataUpdater.updateSingleToken(tokenId);
-        }, this.reactionDelay * 1000);
+        await collectionDataUpdater.updateSingleToken({ [EVENT_DATA_IS_NEW_MINT]: true, tokenId });
       },
     );
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "module": "commonjs",
     "target": "ESNext",
     "declaration": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+
+    "strictNullChecks": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This PR allows custom data to be passed across all the processing elements.
1. `Runtimes` trigger an update populating initial event data
2. `CollectionStatusProviders` can read the event data and update it before the actual "update" operation is run
3. `DataUpdaters` can read the event data and also update it for the next DataUpdaters in the chain